### PR TITLE
Add 'module-zeroconf-discover' to Network Sending instruction.

### DIFF
--- a/configuration/pulseaudio.md
+++ b/configuration/pulseaudio.md
@@ -107,6 +107,7 @@ On the pulseaudio source \(LibreELEC\) device, stop Kodi and find the output dev
 
 ```text
 systemctl stop kodi
+pactl load-module module-zeroconf-discover
 pactl list short sinks
 ```
 


### PR DESCRIPTION
It's not loaded by default and if you want to discover sinks on other
devices, you need that module.

Signed-off-by: Diederik de Haas <github@cknow.org>