### PR TITLE
Explain how to use systemd script to mount NFSv4

### DIFF
--- a/how-to/mount_network_share.md
+++ b/how-to/mount_network_share.md
@@ -20,7 +20,7 @@ Connect to your LibreELEC HTPC with SSH.
 
 #### 2. Create the systemd .mount file
 
-**IMPORTANT:** The filename uses hyphens to separate elements of the fileystem path to the share mount-point, e.g. `/storage/recordings` will be `storage-recordings.mount` and sub folders, e.g. `/storage/recordings/tv` would be `storage-recordings-tv.mount`
+**IMPORTANT:** The filename uses hyphens to separate elements of the filesystem path to the share mount-point, e.g. `/storage/recordings` will be `storage-recordings.mount` and sub folders, e.g. `/storage/recordings/tv` would be `storage-recordings-tv.mount`
 
 Create the .mount file:
 
@@ -132,6 +132,8 @@ Path where the share should be mounted:
 Options: At this section you are able to define specific NFS options, such as NFS version for example. In our example here, we don't need it and we are assuming you are using a NFSv3 share.
 
 Type: `Type=nfs`
+
+If you are using a NFSv4 share, simply replace `Type=nfs` with `Type=nfs4` (see also <https://www.freedesktop.org/software/systemd/man/systemd.mount.html#Type=>)
 
 #### 4. Start it for a test:
 


### PR DESCRIPTION
Documentation assume that most of users will use NFSv3, but for NFSv4 share it is not very easy to find the correct setup. And the `systemctl status storage-recording.mount` does not help too much to debug the problem.

BTW, I am wondering if NFSv4 should not be the default example? I have absolutely no idea which one is more used though.