### PR TITLE
Replace the version numbers in the filenames to the current version

### DIFF
--- a/hardware/amlogic/README.md
+++ b/hardware/amlogic/README.md
@@ -23,9 +23,9 @@ NB: The WeTek Play(1)/OpenELEC box uses Meson 6 (8726MX) hardware. There is litt
 
 `AMLGX` and `AMLMX` provide a "box" image for use with devices that run Amlogic (aka Vendor or Legacy) boot firmware (U-Boot 2015.01 with Amlogic and manufacturer customisations) and "board" images using modern boot firmware (mainline U-Boot) specific to a single SBC board or STB device. The image type can be identified by the filename `-suffix`:
 
-* `LibreELEC-AMLGX.arm-10.0.0-box.img.gz` is the `AMLGX` "box" image
-* `LibreELEC-AMLGX-arm-10.0.0-khadas-vim3.img.gz` is a "board" image for VIM3
-* `LibreELEC-AMLMX-arm-10.0.0-box.img.gz` is a "box" image for Meson 8 devices
+* `LibreELEC-AMLGX.arm-11.0.0-box.img.gz` is the `AMLGX` "box" image
+* `LibreELEC-AMLGX.arm-11.0.0-khadas-vim3.img.gz` is a "board" image for VIM3
+* `LibreELEC-AMLMX.arm-11.0.0-box.img.gz` is a "box" image for Meson 8 devices
 
 ## Box Images
 

--- a/hardware/amlogic/lafrite.md
+++ b/hardware/amlogic/lafrite.md
@@ -15,7 +15,7 @@ LibreComputer preinstalls their eMMC modules with Android, so if you power on th
 3. Run `emmctool d` to detect the module
 4. Run `emmctool z` to erase (zero) the module
 5. Copy the `lafrite` image to `/storage/` on the USB stick
-6. Run `emmctool w /storage/LibreELEC-AMLGX.arm-10.0.0-lafrite.img.gz` to write the `lafrite` image to the eMMC module.
+6. Run `emmctool w /storage/LibreELEC-AMLGX.arm-11.0.0-lafrite.img.gz` to write the `lafrite` image to the eMMC module.
 7. Power off the board, remove the USB stick
 8. Power on the board, and LibreELEC will boot to eMMC and resize /storage
 

--- a/hardware/amlogic/wetek-hub-play2.md
+++ b/hardware/amlogic/wetek-hub-play2.md
@@ -11,15 +11,15 @@ Once the box has booted into the "box" image you can download the latest WeTek "
 Find the URL for the relevant board image on the [download page](https://libreelec.tv/downloads/amlogic/). For example, the LibreELEC v11 beta 1 image for the WeTek Play2 will be:
 
 ```
-https://releases.libreelec.tv/LibreELEC-AMLGX.arm-10.95.0-wetek-play2.img.gz
+https://releases.libreelec.tv/LibreELEC-AMLGX.arm-11.0.0-wetek-play2.img.gz
 ```
 
-Enable SSH and login, then run the following commands to download the board image to /storage and run `emmctool` to write (`w`) the `LibreELEC-AMLGX.arm-10.95.0-wetek-play2.img.gz` image to eMMC:
+Enable SSH and login, then run the following commands to download the board image to /storage and run `emmctool` to write (`w`) the `LibreELEC-AMLGX.arm-11.0.0-wetek-play2.img.gz` image to eMMC:
 
 ```
 cd /storage
-wget https://releases.libreelec.tv/LibreELEC-AMLGX.arm-10.95.0-wetek-play2.img.gz
-emmctool w LibreELEC-AMLGX.arm-10.95.0-wetek-play2.img.gz
+wget https://releases.libreelec.tv/LibreELEC-AMLGX.arm-11.0.0-wetek-play2.img.gz
+emmctool w LibreELEC-AMLGX.arm-11.0.0-wetek-play2.img.gz
 ```
 
 `The emmctool` utility will write the board image to eMMC, expand the /storage partition to 100% size and change the partition labels to `BOOT` and `DISK` to avoid clashing with the default labels used in the SD card image (so you can boot from SD card if needed).


### PR DESCRIPTION
- Replace version numbers in filenames to `11.0.0`.
- Fix some typos in filenames.