### PR TITLE
Fix typo in docker command: --it should be -it

### DIFF
--- a/development/build-docker.md
+++ b/development/build-docker.md
@@ -32,7 +32,7 @@ For a list of commands, see [Build (Basics)](build-basics.md).
 
 ```bash
 docker run \
-  --it --rm \
+  -it --rm \
   --log-driver none \
   -v `pwd`:/build -w /build \
   -e PROJECT=Generic \
@@ -47,7 +47,7 @@ Limit CPU and RAM so your system remains responsive.
 
 ```bash
 docker run \
-  --it --rm \
+  -it --rm \
   --log-driver none \
   -v `pwd`:/build -w /build \
   `# setting these the same disables swapping` \


### PR DESCRIPTION
There is no option --it, but the concatenation of options -i and -t to -it.